### PR TITLE
Fix missing state and date difference

### DIFF
--- a/vite-tailwind-template/src/pages/UserInfoPage.jsx
+++ b/vite-tailwind-template/src/pages/UserInfoPage.jsx
@@ -6,6 +6,8 @@ import NextButton from "../components/NextButton";
 export default function UserInfoPage() {
   const [name, setName] = useState("");
   const [gender, setGender] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const navigate = useNavigate();
 
   // 로그인 후 저장된 userId를 localStorage 등에서 가져옵니다.

--- a/vite-tailwind-template/src/pages/home.jsx
+++ b/vite-tailwind-template/src/pages/home.jsx
@@ -41,7 +41,7 @@ const Home = () => {
 
         // D+N 계산
         const startDate = new Date(userData.keyword?.routines?.[0]?.createdAt);
-        const diffTime = today - startDate;
+        const diffTime = now - startDate;
         const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
         setDPlus(diffDays >= 0 ? `D+${diffDays}` : "D-?");
 


### PR DESCRIPTION
## Summary
- fix missing loading and error states in `UserInfoPage`
- correct date difference calculation in `home`

## Testing
- `npm run build` *(fails: platform mismatch for esbuild)*

------
https://chatgpt.com/codex/tasks/task_e_683fcf81b2608333ae7348fa19c75dad